### PR TITLE
move cache directory to root

### DIFF
--- a/config/dbl.yml
+++ b/config/dbl.yml
@@ -19,7 +19,7 @@ inherit_from:
 AllCops:
   UseCache: true
   MaxFilesInCache: 5
-  CacheRootDirectory: ./tmp/**
+  CacheRootDirectory: /tmp/**
   TargetRubyVersion: 2.7.2
   NewCops: enable
   Exclude:

--- a/config/dbl.yml
+++ b/config/dbl.yml
@@ -19,7 +19,6 @@ inherit_from:
 AllCops:
   UseCache: true
   MaxFilesInCache: 5
-  CacheRootDirectory: /tmp/**
   TargetRubyVersion: 2.7.2
   NewCops: enable
   Exclude:

--- a/config/dbl.yml
+++ b/config/dbl.yml
@@ -16,6 +16,8 @@ inherit_from:
   - cops/style.yml
 
 
+# if you want to change the cache directory, simple set `XDG_CACHE_HOME` for your local shell.
+# see: https://docs.rubocop.org/rubocop/usage/caching.html
 AllCops:
   UseCache: true
   MaxFilesInCache: 5

--- a/config/dbl.yml
+++ b/config/dbl.yml
@@ -16,7 +16,7 @@ inherit_from:
   - cops/style.yml
 
 
-# if you want to change the cache directory, simple set `XDG_CACHE_HOME` for your local shell.
+# if you want to change the cache directory, simple set `RUBOCOP_CACHE_ROOT` for your local shell.
 # see: https://docs.rubocop.org/rubocop/usage/caching.html
 AllCops:
   UseCache: true

--- a/config/dbl.yml
+++ b/config/dbl.yml
@@ -20,7 +20,6 @@ inherit_from:
 # see: https://docs.rubocop.org/rubocop/usage/caching.html
 AllCops:
   UseCache: true
-  MaxFilesInCache: 5
   TargetRubyVersion: 2.7.2
   NewCops: enable
   Exclude:


### PR DESCRIPTION
persisting the cache relative to the current dir creates tones of random files in multipe locations of the codebase, when rubocop is run  relative to a sub dir of the project.

This is very annoying.﻿


As discussed in Slack :)


https://docs.rubocop.org/rubocop/usage/caching.html
> By default, the cache is stored in either $XDG_CACHE_HOME/$UID/rubocop_cache if $XDG_CACHE_HOME is set or in $HOME/.cache/rubocop_cache/ if it’s not.
> 
> The root can be set to a different path in a number of ways (from highest precedence to lowest):
> 
> the --cache-root command line option
> 
> the $RUBOCOP_CACHE_ROOT environment variable
> 
> the AllCops: CacheRootDirectory configuration parameter