### PR TITLE
remove superfluous railties dependency

### DIFF
--- a/lib/generators/rubocop_dbl/install_generator.rb
+++ b/lib/generators/rubocop_dbl/install_generator.rb
@@ -2,6 +2,7 @@
 
 require 'rails/generators/base'
 require 'active_support/core_ext/string'
+require 'railties'
 
 module RubocopDbl
   module Generators

--- a/rubocop-dbl.gemspec
+++ b/rubocop-dbl.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.homepage              = 'https://github.com/dbl-works/rubocop-dbl'
   spec.license               = 'MIT'
   spec.required_ruby_version = '>= 2.7'
-  spec.add_dependency 'railties', '>= 5'
+
   spec.add_dependency 'rubocop', '~> 1'
   spec.add_dependency 'rubocop-ast', '~> 1'
   spec.add_dependency 'rubocop-packaging', '~> 0.5'


### PR DESCRIPTION
Greatly reduces the dependency tree that is installed

projects that want to use the installer that generates the config file must ensure to have railties required (comes by default for Rails apps).