### PR TITLE
Relax Metrics/MethodLength

### DIFF
--- a/config/cops/metrics.yml
+++ b/config/cops/metrics.yml
@@ -17,3 +17,10 @@ Metrics/BlockLength:
     - context
     - feature
     - scenario
+
+Metrics/MethodLength:
+  Max: 30
+  CountAsOne:
+    - array
+    - heredoc
+    - method_call


### PR DESCRIPTION
Relaxes rules for method length by counting arrays, heredocs and method calls as one line, e.g.


```ruby
def foo
  bar(
    arg1: "foo",
    arg2: "bar",
    arg3: "foobar",
  )
end
```

here the method `foo` has a length of 1 LOC allowing to format the code for better git diffs and readability without triggering a rubocop warning.

Also bump the default from 25 to 30 LOC.



https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/MethodLength