### PR TITLE
install Rails Cop only if Rails is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Rails Cops are only enabled, if `Rails` is a defined constant
+- **breaking change** The `rubocop.yml` file must add `config/cops/rails.yml` manually, if Rails is used (or re-run the generator). This is because we can't have dynamic code in YML files.
+
 ## [1.0.1] - 2022-12-30
 ### Changed
 - Fixed loading cops from subdirectory

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ rails generate rubocop_dbl:install
 
 or manually Aad this line to your application's `.rubocop.yml`:
 
+When using Rails:
+
+```yml
+require:
+  - rubocop-rails
+
+inherit_gem:
+  rubocop-dbl:
+    - config/dbl.yml
+    - config/cops/rails.yml
+```
+
+When not using Rails:
+
 ```yml
 inherit_gem:
   rubocop-dbl:

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ end
 
 RuboCop::RakeTask.new
 
-# rubocop:disable Rails/RakeEnvironment
 task :rails_test do
   rails_test_dir = 'rails_test'
   except_cops = %w[
@@ -35,6 +34,5 @@ task :rails_test do
   end
   rm_rf rails_test_dir
 end
-# rubocop:enable Rails/RakeEnvironment
 
 task default: %i[test rubocop rails_test]

--- a/config/dbl.yml
+++ b/config/dbl.yml
@@ -1,7 +1,6 @@
 require:
   - rubocop-packaging
   - rubocop-performance
-  - rubocop-rails
   - rubocop-rspec
   - rubocop-sorbet
 
@@ -12,7 +11,6 @@ inherit_from:
   - cops/metrics.yml
   - cops/naming.yml
   - cops/performance.yml
-  - cops/rails.yml
   - cops/rspec.yml
   - cops/style.yml
   - cops/types.yml
@@ -22,7 +20,7 @@ inherit_from:
 # see: https://docs.rubocop.org/rubocop/usage/caching.html
 AllCops:
   UseCache: true
-  TargetRubyVersion: 2.7.2
+  TargetRubyVersion: 3.1.4
   NewCops: enable
   Exclude:
     - '**/tmp/**/*'

--- a/lib/generators/rubocop_dbl/install_generator.rb
+++ b/lib/generators/rubocop_dbl/install_generator.rb
@@ -1,13 +1,12 @@
 # typed: false
 
 require 'rails/generators/base'
-require 'active_support/core_ext/string'
 require 'railties'
 
 module RubocopDbl
   module Generators
     class InstallGenerator < Rails::Generators::Base
-      desc 'Creates a .rubocop.yml config file that inherits from the official Ruby on Rails .rubocop.yml.'
+      desc 'Creates a .rubocop.yml config file that inherits from the various rubocop gems (Rails optional).'
 
       def create_config_file
         file_method = config_file_exists? ? :prepend : :create
@@ -25,11 +24,24 @@ module RubocopDbl
       end
 
       def config_file_content
-        <<~HEREDOC
-          inherit_gem:
-            rubocop-dbl:
+        if defined?(Rails)
+          <<~HEREDOC
+            require:
+              - rubocop-rails
+
+            inherit_gem:
+              rubocop-dbl:
+                - config/dbl.yml
+                - config/cops/rails.yml
+          HEREDOC
+        else
+          <<~HEREDOC
+
+            inherit_gem:
+              rubocop-dbl:
               - config/dbl.yml
-        HEREDOC
+          HEREDOC
+        end
       end
     end
   end

--- a/rubocop-dbl.gemspec
+++ b/rubocop-dbl.gemspec
@@ -24,9 +24,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-ast', '~> 1'
   spec.add_dependency 'rubocop-packaging', '~> 0.5'
   spec.add_dependency 'rubocop-performance', '~> 1'
-  spec.add_dependency 'rubocop-rails', '~> 2'
   spec.add_dependency 'rubocop-rspec', '~> 2'
   spec.add_dependency 'rubocop-sorbet', '~> 0.6'
+
+  if defined?(::Rails)
+    spec.add_dependency 'rubocop-rails', '~> 2'
+  end
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/rubocop-dbl.gemspec
+++ b/rubocop-dbl.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   ]
   spec.homepage              = 'https://github.com/dbl-works/rubocop-dbl'
   spec.license               = 'MIT'
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency 'rubocop', '~> 1'
   spec.add_dependency 'rubocop-ast', '~> 1'
@@ -27,9 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rspec', '~> 2'
   spec.add_dependency 'rubocop-sorbet', '~> 0.6'
 
-  if defined?(::Rails)
-    spec.add_dependency 'rubocop-rails', '~> 2'
-  end
+  spec.add_dependency 'rubocop-rails', '~> 2' if defined?(Rails)
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
avoid unnecessary deep sub dependencies when Rails is not used