### PR TITLE
fix: Added missing rubocop plugins and removed broken spec dependency condition

### DIFF
--- a/rubocop-dbl.gemspec
+++ b/rubocop-dbl.gemspec
@@ -22,12 +22,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 1'
   spec.add_dependency 'rubocop-ast', '~> 1'
+  spec.add_dependency 'rubocop-factory_bot', '~> 2.27.1'
   spec.add_dependency 'rubocop-packaging', '~> 0.5'
   spec.add_dependency 'rubocop-performance', '~> 1'
+  spec.add_dependency 'rubocop-rails', '~> 2'
   spec.add_dependency 'rubocop-rspec', '~> 3'
+  spec.add_dependency 'rubocop-rspec_rails', '~> 2.31.0'
   spec.add_dependency 'rubocop-sorbet', '~> 0.10'
-
-  spec.add_dependency 'rubocop-rails', '~> 2' if defined?(Rails)
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Based on the discussion here: https://github.com/lh-innovationhub/modifly/pull/2930#discussion_r2056395483  
I have added 2 gems:

* `rubocop-factory_bot`
* `rubocop-rspec_rails`

I also removed the `if defined?(Rails)` from the `rubocop-rails` spec definition.  
It was not working and caused a runtime require error.

In the gem definition, it explicitly states that this gem is for Rails projects.  
Therefore, I figured a conditional requirement of Rails-only RuboCop extensions is not necessary.
```
spec.summary     = ‘RuboCop configuration for our Ruby on Rails projects’
spec.description = ‘RuboCop configuration for our Ruby on Rails projects’
```

Please create a new release version so I can add it to modifly