### PR TITLE
fix: update rubocop plugins to include factory_bot, rails, and rspec_rails

### DIFF
--- a/config/dbl.yml
+++ b/config/dbl.yml
@@ -1,7 +1,10 @@
 plugins:
+  - rubocop-factory_bot
   - rubocop-packaging
   - rubocop-performance
+  - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
   - rubocop-sorbet
 
 inherit_from:


### PR DESCRIPTION
When adding three RuboCop plugin gems in the last release, I forgot to enable them in this config file.
Please create a new Release 2.4.0